### PR TITLE
Base64 编码和 URL 编码

### DIFF
--- a/lib/carrierwave/storage/aliyun.rb
+++ b/lib/carrierwave/storage/aliyun.rb
@@ -52,7 +52,7 @@ module CarrierWave
             "Host" => @aliyun_upload_host,
             "Expect" => "100-Continue"
           }
-          RestClient.put(URI.encode(url), file, headers)
+          RestClient.put(URI.encode(url).gsub("+", "%2B"), file, headers)
           return path_to_url(path, :get => true)
         end
 
@@ -91,7 +91,7 @@ module CarrierWave
             "Authorization" => sign("DELETE", bucket_path, "", "" ,date)
           }
           url = path_to_url(path)
-          RestClient.delete(URI.encode(url), headers)
+          RestClient.delete(URI.encode(url).gsub("+", "%2B"), headers)
           return path_to_url(path, :get => true)
         end
 


### PR DESCRIPTION
当文件名中包含了 "+"，在 OSS 中上传会遇到签名不对应的问题。这是因为 base64 编码中使用了加号（+），而 + 在 URL 传递时会被当成空格，因此必须要将 base64 编码后的字符串中的加号替换成 %2B 才能当作 URL 参数进行传递，否则在服务器端解码后就会出错。

http://readwall.blog.163.com/blog/static/1012713220123245224679
