### PR TITLE
No need to require 'digest/hmac'.

### DIFF
--- a/lib/carrierwave/storage/aliyun.rb
+++ b/lib/carrierwave/storage/aliyun.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'carrierwave'
 require 'digest/md5'
+require 'openssl'
 require "rest-client"
 require 'uri'
 

--- a/lib/carrierwave/storage/aliyun.rb
+++ b/lib/carrierwave/storage/aliyun.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'carrierwave'
-require 'digest/hmac'
 require 'digest/md5'
 require "rest-client"
 require 'uri'


### PR DESCRIPTION
Since there's no call to 'digest/hmac', just remove it.