### PR TITLE
Fix Storage's read

### DIFF
--- a/lib/carrierwave/storage/aliyun_file.rb
+++ b/lib/carrierwave/storage/aliyun_file.rb
@@ -12,7 +12,7 @@ module CarrierWave
       def read
         object = bucket.get(@path)
         @headers = object.headers
-        object.body
+        object
       end
 
       def delete


### PR DESCRIPTION
### 本次 PR 内容

* 修正了 Storage 的 read 方法。

`bucket.get(@path)` 是 `res.parsed_response` ([ref](https://github.com/huacnlee/carrierwave-aliyun/blob/master/lib/carrierwave/aliyun/bucket.rb#L59)) 了，所以这里 object 应该不用再得到它的 body 了，直接返回就好了。