### PR TITLE
实现size方法

### DIFF
--- a/lib/carrierwave/storage/aliyun_file.rb
+++ b/lib/carrierwave/storage/aliyun_file.rb
@@ -3,6 +3,7 @@
 module CarrierWave
   module Storage
     class AliyunFile
+      attr_writer :file
       attr_reader :uploader, :path
 
       alias_method :filename, :path
@@ -10,6 +11,14 @@ module CarrierWave
 
       def initialize(uploader, base, path)
         @uploader, @path, @base = uploader, escape(path), base
+      end
+
+      def file
+        @file ||= bucket.get(path).try(:first)
+      end
+
+      def size
+        file.headers[:content_length].to_i rescue nil
       end
 
       def escape(path)


### PR DESCRIPTION
没有size方法会导致更新图片数组时，新上传的图片会取代旧图片，伪代码：
```ruby
# 预处理数据
upload.files =[a.png]
params[:file] = b.png
# 处理
files = upload.files
files += params[:file]
upload.files = files 
```
最后一步`files=` 会调用
```
...省略前面调用栈
CarrierWave::Mounter#cache(new_files)
CarrierWave::Uploader::Cache#cache!(new_file = sanitized_file)
CarrierWave::SanitizedFile#empty?
```
`empty?`会判断file.size，如无实现则`CarrierWave::Mounter#cache(new_files)`就不会将旧的file uploader实例赋值，导致上传图片被替换的现象